### PR TITLE
added stability_pool_v1 feature for fmo_server build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
                 pname = "fmo_server";
                 version = "0.1.0";
                 src = rustSrc;
-                cargoExtraArgs = "--package=fmo_server";
+                cargoExtraArgs = "--package=fmo_server --features=stability_pool_v1";
                 RUSTFLAGS = "--cfg tokio_unstable";
               });
             in


### PR DESCRIPTION
Changed flake.nix to add the stability_pool_v1 feature flag to the build command. Related to https://github.com/elsirion/fedimint-observer/pull/61